### PR TITLE
Add aggregated JUnit report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+	id 'java'
+	id 'jacoco-report-aggregation'
+}
+
 allprojects {
 
     wrapper {
@@ -8,6 +13,7 @@ allprojects {
 subprojects {
 	apply plugin: 'java'
 	apply plugin: 'checkstyle'
+	apply plugin: 'jacoco'
 
 	dependencies {
 		testImplementation platform('org.junit:junit-bom:5.13.1')
@@ -21,6 +27,17 @@ subprojects {
 		options.debug = true
 		options.debugOptions.debugLevel = 'source,vars,lines'
 		options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'
+	}
+
+    test {
+        useJUnitPlatform()
+    }
+
+	jacocoTestReport {
+		reports {
+			xml.required = true // codecov depends on xml format report
+			html.required = true
+		}
 	}
 
 	checkstyle {

--- a/code-coverage-report/README.md
+++ b/code-coverage-report/README.md
@@ -1,0 +1,4 @@
+# code-coverage-report
+This project only exists to support aggregating the test coverage reports
+from all subprojects into a single report for this entire repository.
+See [here](https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage_distribution.html) for more information.

--- a/code-coverage-report/build.gradle
+++ b/code-coverage-report/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'base'
+    id 'jacoco-report-aggregation'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    jacocoAggregation project(':level-editor')
+}
+
+reporting {
+    reports {
+        testCodeCoverageReport(JacocoCoverageReport) {
+            testSuiteName = "test"
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
+}

--- a/level-editor/build.gradle
+++ b/level-editor/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
 	id 'application'
-	id 'jacoco'
 }
 
 repositories {
@@ -12,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fifesoft.rtext:fife.common:6.0.4-SNAPSHOT'
+    implementation 'com.fifesoft.rtext:fife.common:6.0.3'
     implementation project(':mario-common')
     implementation project(':mario-slick')
 }

--- a/level-editor/src/test/java/org/fife/mario/editor/UtilsTest.java
+++ b/level-editor/src/test/java/org/fife/mario/editor/UtilsTest.java
@@ -11,17 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class UtilsTest {
 
 	@Test
-	void testCreateImageWithAlpha() {
-		BufferedImage orig = new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
-		orig.setRGB(0, 0, 0xFF0000); // Set a pixel to red
-		BufferedImage result = Utils.createImageWithAlpha(orig);
-
-		assertNotNull(result);
-		assertEquals(BufferedImage.TYPE_INT_ARGB, result.getType());
-		assertEquals(0xFFFF0000, result.getRGB(0, 0)); // Should be red with alpha
-	}
-
-	@Test
 	void testGetVerticallyMirroredImage() {
 		BufferedImage orig = new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
 		for (int y = 0; y < 10; y++) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'mario'
 
-include 'mario-common', 'level-editor', 'mario-slick'
+include 'code-coverage-report', 'mario-common', 'level-editor', 'mario-slick'


### PR DESCRIPTION
Aggregate the code coverage across all subprojects into a single coverage report. This is going to hurt because of all of the UI rendering code but should encourage us to refactor as much as possible.